### PR TITLE
fix new entware segmentation fault bug

### DIFF
--- a/keenkit.sh
+++ b/keenkit.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 trap cleanup HUP INT TERM EXIT
-export LD_LIBRARY_PATH=/lib:/usr/lib:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/opt/lib:/opt/usr/lib:$LD_LIBRARY_PATH
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 CYAN='\033[0;36m'
@@ -13,7 +13,7 @@ SCRIPT="keenkit.sh"
 TMP_DIR="/tmp"
 OPT_DIR="/opt"
 STORAGE_DIR="/storage"
-SCRIPT_VERSION="2.7.1"
+SCRIPT_VERSION="2.7.2"
 MIN_RAM_SIZE="256"
 MIN_RAM_SIZE_AARCH64="512"
 PACKAGES_LIST="python3-base python3 python3-light libpython3"


### PR DESCRIPTION
# Bug: Segmentation fault на aarch64 при использовании LD_LIBRARY_PATH

## Симптомы

При запуске `keenkit.sh` на роутерах Keenetic с архитектурой **aarch64** (например, RAX3000M / KN-3812) в меню выводятся ошибки:

```
Bus error
Segmentation fault
Модель:          () |  (слот: 1)
Процессор:      MT7981 (aarch64) | CPU: 76°C
ОЗУ:            0 / 0 MB
OPKG:
Время работы:
```

При этом RCI-эндпоинты (`http://localhost:79/rci/show/version`, `show/system`, `show/interface`) работают корректно и возвращают валидный JSON.

## Причина

Строка 3 в `keenkit.sh`:
```sh
export LD_LIBRARY_PATH=/lib:/usr/lib:$LD_LIBRARY_PATH
```

На роутерах с установленным Entware используется `curl` из пакета Entware (например, curl 8.15.0). При `LD_LIBRARY_PATH` где `/lib:/usr/lib` стоит **перед** путями Entware (`/opt/lib`), curl загружает **системные** библиотеки Keenetic вместо Entware-версий:

| Библиотека | Entware | Системная (Keenetic) |
|------------|---------|---------------------|
| libopenssl | 3.5.5   | другая версия       |
| libc       | 2.27-12 | 2.27 (системная)    |
| libnghttp2 | 1.66.0  | отсутствует           |

Несовместимость версий приводит к **Segmentation fault** при вызове `curl` из функций `get_version_info()`, `get_system_info()`, `get_interface_info()`.

### Почему проявляется не на всех устройствах

- **curl 8.15.0** (Entware aarch64, собранный динамически с nghttp2) — **падает** при конфликте LD_LIBRARY_PATH
- **curl 8.12.1** (Entware, более старая версия) — может работать, так как собран с меньшим количеством зависимостей (без nghttp2)

## Воспроизведение

```sh
# Падает (exit code 139)
LD_LIBRARY_PATH=/lib:/usr/lib curl -s http://localhost:79/rci/show/version > /dev/null
LD_LIBRARY_PATH=/lib:/usr/lib curl -s http://localhost:79/rci/show/system > /dev/null
```

```sh
# Работает корректно
curl -s http://localhost:79/rci/show/version > /dev/null
```

## Решение

Заменить строку 3 в `keenkit.sh`:

**Было:**
```sh
export LD_LIBRARY_PATH=/lib:/usr/lib:$LD_LIBRARY_PATH
```

**Стало:**
```sh
export LD_LIBRARY_PATH=/opt/lib:/opt/usr/lib:$LD_LIBRARY_PATH
```

Это обеспечивает приоритет Entware-библиотек над системными, что предотвращает конфликт версий.

## Затронутые устройства

- **Архитектура:** aarch64 (MT7981)
- **Прошивка:** Keenetic 5.0.6+
- **Entware:** curl 8.15.0, libopenssl 3.5.5, libc 2.27-12
- **Скрипт:** keenkit.sh 2.7.1

## Архитектурный вывод: почему это безопасно

Все утилиты, которые использует скрипт — **из Entware**, а не системные:

| Утилита | Путь |
|---------|------|
| `strings` | `/opt/bin/strings` |
| `grep` | `/opt/usr/bin/grep` |
| `awk` | `/opt/bin/awk` |
| `curl` | `/opt/bin/curl` |
| `jq` | `/opt/bin/jq` |
| `find` | `/opt/bin/find` |
| `cut` | `/opt/usr/bin/cut` |

Системные утилиты (`dd`, `mount`, `reboot`, `sync`, `echo`) — это **BusyBox**, который статически слинкован или берёт библиотеки из `/lib` по умолчанию. Ему `LD_LIBRARY_PATH` безразличен.

Таким образом:
- **Entware-утилиты** — требуют `/opt/lib` (падают без приоритета этих путей)
- **Системные утилиты (BusyBox)** — не зависят от `LD_LIBRARY_PATH`

**Нет ни одного случая**, где системные библиотеки `/lib:/usr/lib` были бы нужны приоритетнее Entware-ных. Исходная строка `export LD_LIBRARY_PATH=/lib:/usr/lib:$LD_LIBRARY_PATH` просто ломает Entware-утилиты и ничего не чинит.

Правка на `export LD_LIBRARY_PATH=/opt/lib:/opt/usr/lib:$LD_LIBRARY_PATH` безопасна и протестирована на двух устройствах (rax1 и rax2).
